### PR TITLE
Potential fix for code scanning alert no. 4: Use of externally-controlled format string

### DIFF
--- a/storage/src/main/java/com/github/advancedsecurity/storageservice/controllers/BlobController.java
+++ b/storage/src/main/java/com/github/advancedsecurity/storageservice/controllers/BlobController.java
@@ -48,7 +48,7 @@ public class BlobController {
             // var path = String.format("%s/%s", profile.name, id.toString());
             var path = String.format("%s", id);
 
-                System.out.format(id + "-local", path );
+                System.out.format("%s-local", id, path );
 
             var stat = minio.statObject(
                 StatObjectArgs


### PR DESCRIPTION
Potential fix for [https://github.com/im-sandbox-thomasp/mona-gallery/security/code-scanning/4](https://github.com/im-sandbox-thomasp/mona-gallery/security/code-scanning/4)

To fix the problem, we should avoid using the user-controlled `id` directly in the format string. Instead, we can use a placeholder (`%s`) in the format string and pass the `id` as an argument to `System.out.format`. This ensures that any format specifiers in the user input are not interpreted by the format method.

- Change the format string to use `%s` as a placeholder.
- Pass the concatenated string (`id + "-local"`) as an argument to `System.out.format`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
